### PR TITLE
TGenEpEmv1: Return bool to indicate init success

### DIFF
--- a/TEPEMGEN/TGenEpEmv1.cxx
+++ b/TEPEMGEN/TGenEpEmv1.cxx
@@ -109,7 +109,7 @@ TGenEpEmv1::~TGenEpEmv1()
 }
 
 //____________________________________________________________
-void TGenEpEmv1::Init()
+bool TGenEpEmv1::Init()
 {
   // Initialisation:
   // 1) define a generator
@@ -124,9 +124,10 @@ void TGenEpEmv1::Init()
   double err = 0;
   fXSection = CalcXSection(fXSectionEps,fMinXSTest,fMaxXSTest,err);
   if (fXSection<=0 || err/fXSection>fXSectionEps) {
-    abort();
+    return false;
   }
   fXSectionEps = err/fXSection;
+  return true;
 }
 
 //____________________________________________________________

--- a/TEPEMGEN/TGenEpEmv1.h
+++ b/TEPEMGEN/TGenEpEmv1.h
@@ -21,10 +21,10 @@ class TGenEpEmv1 : public TEpEmGen {
   
  public:
   TGenEpEmv1();
-  virtual ~TGenEpEmv1();
+  ~TGenEpEmv1() override;
 
-  virtual void GenerateEvent();
-  virtual void Init();
+  void GenerateEvent() override; // interface of TGenerator
+  bool Init(); // init function; returns true if successful; false otherwise
   void SetDebug(Int_t debug) {fDebug=debug;}
   void SetYRange(Double_t min, Double_t max) {fYMin = min; fYMax = max;};
   void SetPtRange(Double_t min, Double_t max) {fPtMin = min; fPtMax = max;};


### PR DESCRIPTION
Currently TGenEpEmv1 fails when the initialization fails (sampling of X-section).
This is sub-optimal since such abort will bring down complete MC jobs the GRID.

This commit allows the caller to react to such error condition. The caller may decide what to do (give it another go or to exit).