### PR TITLE
Speedup event generation by caching TF1

### DIFF
--- a/GeneratorParam/GeneratorParam.h
+++ b/GeneratorParam/GeneratorParam.h
@@ -23,6 +23,7 @@
 #include <TMath.h>
 #include <TVector3.h>
 #include <TVirtualMCDecayer.h>
+#include <map>
 class TF1;
 typedef enum { kNoSmear, kPerEvent, kPerTrack } VertexSmear_t;
 typedef enum { kAnalog, kNonAnalog } Weighting_t;
@@ -214,6 +215,8 @@ protected:
     kMomentumRange = BIT(19),
     kEtaRange = BIT(20)
   };
+
+  std::map<int, std::unique_ptr<TF1>> fPDGtoTF1; //! map of cache TF1 objects for "exodus"
 
 private:
   void InitChildSelect();


### PR DESCRIPTION
Improves speed of event generation by
(a) caching TF1 objects
(b) avoiding call to TF1::SetParameter (because this
    invalidates the cache for TF1::GetRandom))

+ minor change of pow(x, 0.333) --> std::cbrt(x)