### PR TITLE
Integrate Pythia6 source code and linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(AEGIS)
 
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+
 add_subdirectory(MICROCERN)
 
 add_subdirectory(TEPEMGEN)

--- a/GeneratorParam/CMakeLists.txt
+++ b/GeneratorParam/CMakeLists.txt
@@ -9,6 +9,8 @@ list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 #---Locate the ROOT package and defines a number of variables (e.g. ROOT_INCLUDE_DIRS)
 find_package(ROOT REQUIRED COMPONENTS EG)
 
+find_package(Pythia6)
+
 #---Define useful ROOT functions and macros (e.g. ROOT_GENERATE_DICTIONARY)
 include(${ROOT_USE_FILE})
 
@@ -21,13 +23,13 @@ endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/.)
 
-set(HEADERS GeneratorParam.h GeneratorParamLibBase.h GeneratorParamMUONlib.h GeneratorParamEMlib.h GeneratorParamEMlibV2.h PythiaDecayerConfig.h ExodusDecayer.h)
+set(HEADERS GeneratorParam.h GeneratorParamLibBase.h GeneratorParamMUONlib.h GeneratorParamEMlib.h GeneratorParamEMlibV2.h PythiaDecayerConfig.h ExodusDecayer.h TPythia6Decayer.h TPythia6.h TMCParticle.h)
 
 ROOT_GENERATE_DICTIONARY(G__GeneratorParam ${HEADERS} LINKDEF GeneratorParamLinkDef.h)
 
 #---Create a shared library with geneated dictionary
-add_library(GeneratorParam SHARED GeneratorParam.cxx GeneratorParamLibBase.cxx GeneratorParamMUONlib.cxx GeneratorParamEMlib.cxx GeneratorParamEMlibV2.cxx PythiaDecayerConfig.cxx ExodusDecayer.cxx G__GeneratorParam.cxx)
-target_link_libraries(GeneratorParam ${ROOT_LIBRARIES} ${VMC_LIBRARIES})
+add_library(GeneratorParam SHARED GeneratorParam.cxx GeneratorParamLibBase.cxx GeneratorParamMUONlib.cxx GeneratorParamEMlib.cxx GeneratorParamEMlibV2.cxx PythiaDecayerConfig.cxx ExodusDecayer.cxx TPythia6.cxx TPythia6Decayer.cxx TMCParticle.cxx G__GeneratorParam.cxx)
+target_link_libraries(GeneratorParam ${ROOT_LIBRARIES} ${VMC_LIBRARIES} ${PYTHIA6_LIBRARY})
 
 
 set_target_properties(GeneratorParam

--- a/GeneratorParam/GeneratorParamLinkDef.h
+++ b/GeneratorParam/GeneratorParamLinkDef.h
@@ -11,5 +11,8 @@
 #pragma link C++ class GeneratorParamEMlibV2+;
 #pragma link C++ class PythiaDecayerConfig+;
 #pragma link C++ class ExodusDecayer+;
+#pragma link C++ class TPythia6+;
+#pragma link C++ class TPythia6Decayer+;
+#pragma link C++ class TMCParticle+;
 
 #endif

--- a/GeneratorParam/PythiaDecayerConfig.h
+++ b/GeneratorParam/PythiaDecayerConfig.h
@@ -19,9 +19,10 @@
 // Allows to force decay channels.
 // Author: andreas.morsch@cern.ch
 
-#include <TPythia6.h>
 #include <TLorentzVector.h>
 #include "ExodusDecayer.h"
+
+class TPythia6;
 
 typedef enum {
   kBSemiElectronic,

--- a/cmake/modules/FindPythia6.cmake
+++ b/cmake/modules/FindPythia6.cmake
@@ -1,0 +1,61 @@
+# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.
+# All rights reserved.
+#
+# For the licensing terms see $ROOTSYS/LICENSE.
+# For the list of contributors see $ROOTSYS/README/CREDITS.
+
+# File taken from ROOT project
+
+# - Locate pythia6 library
+# Defines:
+#
+#  PYTHIA6_FOUND
+#  PYTHIA6_INCLUDE_DIR
+#  PYTHIA6_INCLUDE_DIRS (not cached)
+#  PYTHIA6_LIBRARY
+#  PYTHIA6_LIBRARY_DIR (not cached)
+#  PYTHIA6_LIBRARIES (not cached)
+
+set(_pythia6dirs
+  ${PYTHIA6}
+  $ENV{PYTHIA6}
+  ${PYTHIA6_DIR}
+  $ENV{PYTHIA6_DIR})
+
+find_path(PYTHIA6_INCLUDE_DIR general_pythia.inc
+           HINTS ${_pythia6dirs}
+           PATH_SUFFIXES include
+           DOC "Specify the Pythia6 include dir here.")
+
+if(PYTHIA6_INCLUDE_DIR)
+  set(PYTHIA6_INCLUDE_DIRS ${PYTHIA6_INCLUDE_DIR})
+endif()
+
+find_library(PYTHIA6_LIBRARY NAMES pythia6 Pythia6
+             HINTS ${_pythia6dirs}
+             PATH_SUFFIXES lib
+             DOC "Specify the Pythia6 library here.")
+
+set(PYTHIA6_LIBRARIES ${PYTHIA6_LIBRARY})
+
+foreach(lib rootinterface pythia6_dummy)
+  find_library(PYTHIA6_${lib}_LIBRARY NAMES ${lib}
+             HINTS ${_pythia6dirs}
+             PATH_SUFFIXES lib
+             DOC "Specify the Pythia rootinterface library here.")
+  if(PYTHIA6_${lib}_LIBRARY)
+    list(APPEND PYTHIA6_LIBRARIES ${PYTHIA6_${lib}_LIBRARY})
+  endif()
+endforeach()
+
+get_filename_component(PYTHIA6_LIBRARY_DIR ${PYTHIA6_LIBRARY} PATH)
+
+# handle the QUIETLY and REQUIRED arguments and set PHOTOS_FOUND to TRUE if
+# all listed variables are TRUE
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Pythia6 DEFAULT_MSG PYTHIA6_LIBRARY)
+
+mark_as_advanced(PYTHIA6_INCLUDE_DIR
+                 PYTHIA6_LIBRARY
+                 PYTHIA6_rootinterface_LIBRARY)


### PR DESCRIPTION
ROOT deprecates support for TPythia6[Decayer].

This commit works around this by moving relevant code from ROOT to AEGIS and by also modifying the CMake files to find and link against Pythia6.