### PR TITLE
Update and extend GeneratorSpectators

### DIFF
--- a/GeneratorSpectators/GeneratorSpectators.C
+++ b/GeneratorSpectators/GeneratorSpectators.C
@@ -1,0 +1,62 @@
+#include "FairGenerator.h"
+#include "GeneratorSpectators.h"
+#include "Generators/GeneratorTGenerator.h"
+#include <fairlogger/Logger.h>
+
+class GeneratorSpectatorsO2 : public o2::eventgen::GeneratorTGenerator {
+
+public:
+  GeneratorSpectatorsO2() : GeneratorTGenerator("GeneratorSpectators", "GeneratorSpectators") {
+    spec = new GeneratorSpectators();
+    setTGenerator(spec);
+  };
+
+  ~GeneratorSpectatorsO2() { delete spec; };
+
+  Bool_t Init() override {
+    spec->Init();
+    return true;
+  }
+
+  void updateHeader(o2::dataformats::MCEventHeader *eventHeader) final {
+    // not updating the header, just printing particles for the time being
+    LOG(info) << Form("--- Number of particles: %zu ---", mParticles.size());
+    for (int i = 0; i < mParticles.size(); ++i) {
+      auto &p = mParticles[i];
+      LOG(info) << Form(
+          "PdgCode: %d, FirstMother: %d, FirstDaughter: %d, LastDaughter: %d",
+          p.GetPdgCode(), p.GetFirstMother(), p.GetFirstDaughter(),
+          p.GetLastDaughter());
+    }
+  }
+
+  GeneratorSpectators* getGenerator() const { return spec; }
+
+private:
+  GeneratorSpectators *spec = nullptr;
+};
+
+FairGenerator *GeneratorSingleNeutron() {
+  auto wrap = new GeneratorSpectatorsO2();
+  auto spec = wrap->getGenerator();
+  spec->SetNpart(1);
+  spec->SetMomentum(5360. / 2.);
+  spec->SetDirection(0, 0., 0., 1.);
+  spec->SetDivergence(0.000032);  // beam divergence in murad
+  spec->SetCrossing(0.000070, 2); // beam crossing angle in murad
+  return wrap;
+}
+
+FairGenerator *GeneratorNeutrons(int nNeutrons = -1, float b = -1., bool useFluctuation = false) {
+  auto wrap = new GeneratorSpectatorsO2();
+  auto spec = wrap->getGenerator();
+  spec->SetImpactParameter(b);
+  spec->SetNpartFluctuation(useFluctuation);
+  spec->SetNpart(nNeutrons);
+  spec->SetMomentum(5360. / 2.);
+  spec->SetDirection(0, 0., 0., 1.);
+  spec->SetDivergence(0.000032);  // beam divergence in murad
+  spec->SetCrossing(0.000070, 2); // beam crossing angle in murad
+  return wrap;
+}
+

--- a/GeneratorSpectators/GeneratorSpectators.C
+++ b/GeneratorSpectators/GeneratorSpectators.C
@@ -43,7 +43,6 @@ FairGenerator *GeneratorSingleNeutron() {
   spec->SetMomentum(5360. / 2.);
   spec->SetDirection(0, 0., 0., 1.);
   spec->SetDivergence(0.000032);  // beam divergence in murad
-  spec->SetCrossing(0.000070, 2); // beam crossing angle in murad
   return wrap;
 }
 
@@ -56,7 +55,6 @@ FairGenerator *GeneratorNeutrons(int nNeutrons = -1, float b = -1., bool useFluc
   spec->SetMomentum(5360. / 2.);
   spec->SetDirection(0, 0., 0., 1.);
   spec->SetDivergence(0.000032);  // beam divergence in murad
-  spec->SetCrossing(0.000070, 2); // beam crossing angle in murad
   return wrap;
 }
 

--- a/GeneratorSpectators/GeneratorSpectators.cxx
+++ b/GeneratorSpectators/GeneratorSpectators.cxx
@@ -360,7 +360,7 @@ void GeneratorSpectators::InitParameterizations() {
 Double_t GeneratorSpectators::ImpParFunc(Double_t *x, Double_t *par) {
   // Function for parameterization of impact parameter distribution
   // from fit to Pb-Pb at 5.02 TeV
-  if (x[0] < 1.e-3 or x[0] > 16.5)
+  if (x[0] < 5.e-2 or x[0] > 16.5)
     return 0.0;
 
   if (x[0] < 13.8)

--- a/GeneratorSpectators/GeneratorSpectators.cxx
+++ b/GeneratorSpectators/GeneratorSpectators.cxx
@@ -75,7 +75,6 @@ void GeneratorSpectators::GenerateEvent() {
     // Generate one trigger particle (n or p)
     Double_t pLab[3] = {0., 0., 0.};
     Double_t fP[3] = {0., 0., 0.};
-    Double_t fBoostP[3] = {0., 0., 0.};
     Double_t ptot = fPtot;
 
     if (fPseudoRapidity == 0.) {
@@ -130,10 +129,8 @@ void GeneratorSpectators::GenerateEvent() {
       TLorentzVector pFermi(dddp[0], dddp[1], dddp[2], dddp0);
       pFermi.Boost(b);
 
-      for (int i = 0; i < 3; i++) {
-        fBoostP[i] = pFermi[i];
+      for (int i = 0; i < 3; i++)
         fP[i] = pFermi[i];
-      }
     }
 
     if (fDebug)
@@ -181,9 +178,9 @@ Int_t GeneratorSpectators::SampleNpart(Float_t impactParameter) {
   }
 
   if (fDebug)
-    printf(" Number of particles to be generated: %d\n", (Int_t)npart);
+    printf(" Number of particles to be generated: %d\n", TMath::Nint(npart));
 
-  return (Int_t)npart;
+  return TMath::Nint(npart);
 }
 
 void GeneratorSpectators::FermiTwoGaussian(Float_t A) {

--- a/GeneratorSpectators/GeneratorSpectators.cxx
+++ b/GeneratorSpectators/GeneratorSpectators.cxx
@@ -23,20 +23,17 @@
 
 #include "GeneratorSpectators.h"
 
-ClassImp(GeneratorSpectators)
-
-//_____________________________________________________________________________
 GeneratorSpectators::GeneratorSpectators()
-   :TGenerator("GeneratorSpectators", "GeneratorSpectators"), fDebug(0),
-   fPDGcode(0), fPmax(0), fPseudoRapidity(0), fCosx(0), fCosy(0), fCosz(0),
-   fFermiflag(1),fBeamDiv(0), fBeamCrossAngle(0), fBeamCrossPlane(0) {
+    : TGenerator("GeneratorSpectators", "GeneratorSpectators"), fDebug(0),
+      fPDGcode(0), fPmax(0), fPseudoRapidity(0), fCosx(0), fCosy(0), fCosz(0),
+      fFermiflag(1), fBeamDiv(0), fBeamCrossAngle(0), fBeamCrossPlane(0) {
   //
   // Default constructor
+  //
 }
 
-//_____________________________________________________________________________
 GeneratorSpectators::GeneratorSpectators(Int_t npart)
-   :TGenerator("GeneratorSpectators", "GeneratorSpectators"){
+    : TGenerator("GeneratorSpectators", "GeneratorSpectators") {
   //
   // Standard constructor
   //
@@ -57,11 +54,8 @@ GeneratorSpectators::GeneratorSpectators(Int_t npart)
   }
 }
 
-//_____________________________________________________________________________
-void GeneratorSpectators::Init()
-{
-  //Initialize Fermi momentum distributions for Pb-Pb
-  //
+void GeneratorSpectators::Init() {
+  // Initialize Fermi momentum distributions for Pb-Pb
   printf("\n **** GeneratorSpectators initialization:\n");
   printf("   ParticlePDG: %d, Track: cosx = %f cosy = %f cosz = %f \n", fPDGcode, fCosx, fCosy, fCosz);
   printf("   Fermi flag: %d, Beam divergence: %f, Crossing angle: %f, plane: %d\n\n",
@@ -70,75 +64,84 @@ void GeneratorSpectators::Init()
   FermiTwoGaussian(208.);
 }
 
-//_____________________________________________________________________________
-void GeneratorSpectators::GenerateEvent()
-{
-  //
+void GeneratorSpectators::GenerateEvent() {
   // Generate one trigger particle (n or p)
-  //
-  //printf("GeneratorSpectators::GenerateEvent()\n");
   fParticles->Clear();
 
   Double_t pLab[3] = {0.,0.,0.};
-  Double_t fP[3] = {0.,0.,0.}, fBoostP[3] = {0.,0.,0.};
+  Double_t fP[3] = {0., 0., 0.};
+  Double_t fBoostP[3] = {0., 0., 0.};
   Double_t ptot = fPmax;
-  if(fPseudoRapidity==0.){
+
+  if (fPseudoRapidity == 0.) {
     pLab[0] = ptot*fCosx;
     pLab[1] = ptot*fCosy;
     pLab[2] = ptot*fCosz;
-  }
-  else{
+  } else {
     Float_t scang = 2*TMath::ATan(TMath::Exp(-(fPseudoRapidity)));
     pLab[0] = -ptot*TMath::Sin(scang);
     pLab[1] = 0.;
     pLab[2] = ptot*TMath::Cos(scang);
   }
-  for(int i=0; i<3; i++) fP[i] = pLab[i];
- if(fDebug==1) printf("\n Particle momentum before divergence and crossing: ");
- if(fDebug==1) printf(" 	pLab = (%f, %f, %f)\n", pLab[0], pLab[1], pLab[2]);
+
+  for (int i = 0; i < 3; i++)
+    fP[i] = pLab[i];
+
+  if (fDebug == 1) {
+    printf("\n Particle momentum before divergence and crossing: ");
+    printf(" 	pLab = (%f, %f, %f)\n", pLab[0], pLab[1], pLab[2]);
+  }
 
   // Beam divergence and crossing angle
   if(TMath::Abs(fBeamCrossAngle)>0.) {
     BeamCrossing(pLab);
-    for(int i=0; i<3; i++) fP[i] = pLab[i];
+    for (int i = 0; i < 3; i++)
+      fP[i] = pLab[i];
   }
   if(TMath::Abs(fBeamDiv)>0.) {
     BeamDivergence(pLab);
-    for(int i=0; i<3; i++) fP[i] = pLab[i];
+    for (int i = 0; i < 3; i++)
+      fP[i] = pLab[i];
   }
 
   Double_t mass = TDatabasePDG::Instance()->GetParticle(fPDGcode)->Mass();
-  Double_t ddp[3] = {0.,0.,0.}, dddp[3] = {0.,0.,0.};
-  Double_t fP0 = 0., dddp0 = 0.;
+  Double_t ddp[3] = {0., 0., 0.};
+  Double_t dddp[3] = {0., 0., 0.};
+  Double_t fP0 = 0.;
+  Double_t dddp0 = 0.;
+
   // If required apply the Fermi momentum
   if(fFermiflag==1){
-    if((fPDGcode==kProton) || (fPDGcode==kNeutron)) ExtractFermi(fPDGcode, ddp);
+    if (fPDGcode == kProton || fPDGcode == kNeutron)
+      ExtractFermi(fPDGcode, ddp);
     fP0 = TMath::Sqrt(fP[0]*fP[0] + fP[1]*fP[1] + fP[2]*fP[2] + mass*mass);
-    for(int i=0; i<3; i++) dddp[i] = ddp[i];
+    for (int i = 0; i < 3; i++)
+      dddp[i] = ddp[i];
     dddp0 = TMath::Sqrt(dddp[0]*dddp[0] + dddp[1]*dddp[1] + dddp[2]*dddp[2] + mass*mass);
 
     TVector3 b(fP[0]/fP0, fP[1]/fP0, fP[2]/fP0);
     TLorentzVector pFermi(dddp[0], dddp[1], dddp[2], dddp0);
-
     pFermi.Boost(b);
+
     for(int i=0; i<3; i++){
        fBoostP[i] = pFermi[i];
        fP[i] = pFermi[i];
     }
-
   }
- if(fDebug==1) printf(" ### Particle momentum = (%f, %f, %f)\n", fP[0], fP[1], fP[2]);
 
-  Double_t energy = TMath::Sqrt(fP[0]*fP[0]+fP[1]*fP[1]+fP[2]*fP[2]+mass*mass);
+  if (fDebug == 1)
+    printf(" ### Particle momentum = (%f, %f, %f)\n", fP[0], fP[1], fP[2]);
 
-  auto part = new TParticle(fPDGcode, 1, -1, -1, -1, -1, fP[0], fP[1], fP[2], energy,
-                              0., 0., 0., 0.);
+  Double_t energy =
+      TMath::Sqrt(fP[0] * fP[0] + fP[1] * fP[1] + fP[2] * fP[2] + mass * mass);
+  auto part = new TParticle(fPDGcode, 1, -1, -1, -1, -1, fP[0], fP[1], fP[2],
+                            energy, 0., 0., 0., 0.);
   fParticles->Add(part);
 }
 
-// -----------------------------------------------------------------------
 int GeneratorSpectators::ImportParticles(TClonesArray *particles, Option_t *option) {
-  if (particles == 0) return 0;
+  if (particles == 0)
+    return 0;
   TClonesArray &clonesParticles = *particles;
   clonesParticles.Clear();
   Int_t numpart = fParticles->GetEntries();
@@ -146,54 +149,53 @@ int GeneratorSpectators::ImportParticles(TClonesArray *particles, Option_t *opti
     TParticle *particle = (TParticle *)fParticles->At(i);
     new (clonesParticles[i]) TParticle(*particle);
   }
+
   return numpart;
 }
 
-//_____________________________________________________________________________
-void GeneratorSpectators::FermiTwoGaussian(Float_t A)
-{
-//
-// Momenta distributions according to the "double-gaussian"
-// distribution (Ilinov) - equal for protons and neutrons
-//
-   Double_t sig1 = 0.113;
-   Double_t sig2 = 0.250;
-   Double_t alfa = 0.18*(TMath::Power((A/12.), (Float_t)1/3));
-   Double_t xk = (2*TMath::TwoPi())/((1.+alfa)*(TMath::Power(TMath::TwoPi(),1.5)));
+void GeneratorSpectators::FermiTwoGaussian(Float_t A) {
+  // Momenta distributions according to the "double-gaussian"
+  // distribution (Ilinov) - equal for protons and neutrons
+  Double_t sig1 = 0.113;
+  Double_t sig2 = 0.250;
+  Double_t alfa = 0.18 * (TMath::Power((A / 12.), (Float_t)1 / 3));
+  Double_t xk = (2 * TMath::TwoPi()) /
+                ((1. + alfa) * (TMath::Power(TMath::TwoPi(), 1.5)));
 
-   for(Int_t i=1; i<201; i++){
-      Double_t p = i*0.005;
-      fPp[i] = p;
-      Double_t e1 = (p*p)/(2.*sig1*sig1);
-      Double_t e2 = (p*p)/(2.*sig2*sig2);
-      Double_t f1 = TMath::Exp(-(e1));
-      Double_t f2 = TMath::Exp(-(e2));
-      Double_t probp = xk*p*p*(f1/(TMath::Power(sig1,3.))+
-                      alfa*f2/(TMath::Power(sig2,3.)))*0.005;
-      fProbintp[i] = fProbintp[i-1] + probp;
-      fProbintn[i] = fProbintp[i];
-   }
-  if(fDebug==1) printf("		Initialization of Fermi momenta distribution \n");
-}
-//_____________________________________________________________________________
-void GeneratorSpectators::ExtractFermi(Int_t id, Double_t *ddp)
-{
-  //
-  // Compute Fermi momentum for spectator nucleons
-  //
-  Int_t index=0;
-  Float_t xx = gRandom->Rndm();
-  assert ( id==kProton || id==kNeutron );
-  if(id==kProton){
-    for(Int_t i=1; i<201; i++){
-       if((xx>=fProbintp[i-1]) && (xx<fProbintp[i])) break;
-       index = i;
-    }
+  for (Int_t i = 1; i < 201; i++) {
+    Double_t p = i * 0.005;
+    fPp[i] = p;
+    Double_t e1 = (p * p) / (2. * sig1 * sig1);
+    Double_t e2 = (p * p) / (2. * sig2 * sig2);
+    Double_t f1 = TMath::Exp(-(e1));
+    Double_t f2 = TMath::Exp(-(e2));
+    Double_t probp =
+        xk * p * p *
+        (f1 / (TMath::Power(sig1, 3.)) + alfa * f2 / (TMath::Power(sig2, 3.))) *
+        0.005;
+    fProbintp[i] = fProbintp[i - 1] + probp;
+    fProbintn[i] = fProbintp[i];
   }
-  else {
+  if (fDebug == 1)
+    printf("		Initialization of Fermi momenta distribution \n");
+}
+
+void GeneratorSpectators::ExtractFermi(Int_t id, Double_t *ddp) {
+  // Compute Fermi momentum for spectator nucleons
+  Int_t index = 0;
+  Float_t xx = gRandom->Rndm();
+  assert(id == kProton || id == kNeutron);
+  if (id == kProton) {
     for(Int_t i=1; i<201; i++){
-       if((xx>=fProbintn[i-1]) && (xx<fProbintn[i])) break;
-       index = i;
+      if ((xx >= fProbintp[i - 1]) && (xx < fProbintp[i]))
+        break;
+      index = i;
+    }
+  } else {
+    for(Int_t i=1; i<201; i++){
+      if ((xx >= fProbintn[i - 1]) && (xx < fProbintn[i]))
+        break;
+      index = i;
     }
   }
   Float_t pext = fPp[index]+0.001;
@@ -204,27 +206,29 @@ void GeneratorSpectators::ExtractFermi(Int_t id, Double_t *ddp)
   ddp[1] = pext*TMath::Sin(tet)*TMath::Sin(phi);
   ddp[2] = pext*cost;
 
- if(fDebug==1) printf(" Fermi momentum: p = (%f, %f, %f )\n\n",ddp[0],ddp[1],ddp[2]);
+  if (fDebug == 1)
+    printf(" Fermi momentum: p = (%f, %f, %f )\n\n", ddp[0], ddp[1], ddp[2]);
 }
-//_____________________________________________________________________________
+
 void GeneratorSpectators::BeamCrossing(Double_t *pLab)
 {
   // Applying beam crossing angle
-  //
   pLab[1] = pLab[2]*TMath::Sin(fBeamCrossAngle)+pLab[1]*TMath::Cos(fBeamCrossAngle);
-  pLab[2] = pLab[2]*TMath::Cos(fBeamCrossAngle)-pLab[1]*TMath::Sin(fBeamCrossAngle);
-  //
- if(fDebug==1) printf(" Beam crossing angle = %f mrad -> ", fBeamCrossAngle*1000.);
- if(fDebug==1) printf("  p = (%f, %f, %f)\n",pLab[0],pLab[1],pLab[2]);
+  pLab[2] = pLab[2] * TMath::Cos(fBeamCrossAngle) -
+            pLab[1] * TMath::Sin(fBeamCrossAngle);
 
+  if (fDebug == 1) {
+    printf(" Beam crossing angle = %f mrad -> ", fBeamCrossAngle * 1000.);
+    printf("  p = (%f, %f, %f)\n", pLab[0], pLab[1], pLab[2]);
+  }
 }
-//_____________________________________________________________________________
+
 void GeneratorSpectators::BeamDivergence(Double_t *pLab)
 {
   // Applying beam divergence and crossing angle
-  //
   Double_t pmq = 0.;
-  for(int i=0; i<3; i++) pmq = pmq+pLab[i]*pLab[i];
+  for (int i = 0; i < 3; i++)
+    pmq = pmq + pLab[i] * pLab[i];
   Double_t pmod = TMath::Sqrt(pmq);
 
   Double_t rvec = gRandom->Gaus(0.0,1.0);
@@ -233,9 +237,15 @@ void GeneratorSpectators::BeamDivergence(Double_t *pLab)
 
   Double_t tetpart = TMath::ATan2(TMath::Sqrt(pLab[0]*pLab[0]+pLab[1]*pLab[1]),pLab[2]);
   Double_t fipart = 0.;
-  if(pLab[1]!=0. || pLab[0]!=0.) fipart = TMath::ATan2(pLab[1],pLab[0]);
-  else fipart = 0.;
-  if(fipart<0.) {fipart = fipart+TMath::TwoPi();}
+
+  if (pLab[1] != 0. || pLab[0] != 0.)
+    fipart = TMath::ATan2(pLab[1], pLab[0]);
+  else
+    fipart = 0.;
+
+  if (fipart < 0.)
+    fipart = fipart + TMath::TwoPi();
+
   tetdiv = tetdiv*TMath::RadToDeg();
   fidiv = fidiv*TMath::RadToDeg();
   tetpart = tetpart*TMath::RadToDeg();
@@ -249,15 +259,17 @@ void GeneratorSpectators::BeamDivergence(Double_t *pLab)
   pLab[0] = pmod*TMath::Sin(tetsum)*TMath::Cos(fisum);
   pLab[1] = pmod*TMath::Sin(tetsum)*TMath::Sin(fisum);
   pLab[2] = pmod*TMath::Cos(tetsum);
-  //
- if(fDebug==1) printf(" Beam divergence = %f mrad -> ", fBeamDiv*1000.);
- if(fDebug==1) printf("  p = (%f, %f, %f)\n",pLab[0],pLab[1],pLab[2]);
+
+  if (fDebug == 1) {
+    printf(" Beam divergence = %f mrad -> ", fBeamDiv * 1000.);
+    printf("  p = (%f, %f, %f)\n", pLab[0], pLab[1], pLab[2]);
+  }
 }
 
 //_____________________________________________________________________________
-void  GeneratorSpectators::AddAngle(Double_t theta1, Double_t phi1, Double_t theta2,
-  	       Double_t phi2, Double_t *angleSum)
-{
+void GeneratorSpectators::AddAngle(Double_t theta1, Double_t phi1,
+                                   Double_t theta2, Double_t phi2,
+                                   Double_t *angleSum) {
   // Calculating the sum of 2 angles
   Double_t temp = -1.;
   Double_t conv = 180./TMath::ACos(temp);
@@ -276,16 +288,21 @@ void  GeneratorSpectators::AddAngle(Double_t theta1, Double_t phi1, Double_t the
   Double_t rtetsum = TMath::ACos(cz);
   Double_t tetsum = conv*rtetsum;
   Double_t fisum = 0;
-  if (tetsum == 0. || tetsum == 180.)
-  {
+
+  if (tetsum == 0. || tetsum == 180.) {
     fisum = 0.;
     return;
   }
+
   temp = cx/TMath::Sin(rtetsum);
-  if(temp>1.) temp=1.;
-  else if (temp < -1.) temp = -1.;
+  if (temp > 1.)
+    temp = 1.;
+  else if (temp < -1.)
+    temp = -1.;
+
   fisum = conv*TMath::ACos(temp);
-  if(cy<0) {fisum = 360.-fisum;}
+  if (cy < 0)
+    fisum = 360. - fisum;
   angleSum[0] = tetsum;
   angleSum[1] = fisum;
 }

--- a/GeneratorSpectators/GeneratorSpectators.cxx
+++ b/GeneratorSpectators/GeneratorSpectators.cxx
@@ -181,7 +181,7 @@ Int_t GeneratorSpectators::SampleNpart(Float_t impactParameter) {
   }
 
   if (fDebug)
-    printf(" Number of particles to be generated: %d\n", npart);
+    printf(" Number of particles to be generated: %d\n", (Int_t)npart);
 
   return (Int_t)npart;
 }
@@ -240,7 +240,7 @@ void GeneratorSpectators::ExtractFermi(Int_t id, Double_t *ddp) {
   ddp[2] = pext*cost;
 
   if (fDebug)
-    printf(" Fermi momentum: p = (%f, %f, %f )\n\n", ddp[0], ddp[1], ddp[2]);
+    printf(" Fermi momentum: p = (%f, %f, %f )\n", ddp[0], ddp[1], ddp[2]);
 }
 
 void GeneratorSpectators::BeamCrossing(Double_t *pLab)

--- a/GeneratorSpectators/GeneratorSpectators.h
+++ b/GeneratorSpectators/GeneratorSpectators.h
@@ -26,14 +26,6 @@ public:
   virtual void GenerateEvent();
   virtual int ImportParticles(TClonesArray *particles, Option_t *option);
 
-  // Fermi smearing, beam divergence and crossing angle
-  void FermiTwoGaussian(Float_t A);
-  void ExtractFermi(Int_t id, Double_t *ddp);
-  void BeamDivergence(Double_t *pLab);
-  void BeamCrossing(Double_t *pLab);
-  void AddAngle(Double_t theta1, Double_t phi1, Double_t theta2, Double_t phi2,
-                Double_t *angle);
-
   // Parameters that could be set for generation
   void SetDebug() { fDebug = kTRUE; }
   void SetParticle(Int_t pdgcode = 2112) { fPDGcode = pdgcode; }
@@ -45,7 +37,7 @@ public:
     fCosy = cosy;
     fCosz = cosz;
   }
-  void SetFermi(Int_t Fflag = 1) { fFermiflag = Fflag; }
+  void SetFermi(Int_t flag = 1) { fFermiflag = flag; }
   void SetDivergence(Float_t bmdiv = 0.000032) { fBeamDiv = bmdiv; }
   void SetCrossing(Float_t xingangle = 0.0001, Int_t xingplane = 2) {
     fBeamCrossAngle = xingangle;
@@ -58,7 +50,7 @@ public:
   Float_t GetZDirection() const { return fCosz; }
 
 protected:
-  Int_t    fDebug;              // debugging Fflag
+  Int_t    fDebug;              // Debugging flag
   Int_t    fPDGcode;            // Particle to be generated - can be n (2112) or p (2212)
   Float_t  fPmax;               // Maximum slow nucleon momentum
   Float_t  fPseudoRapidity;     // Pseudorapidity: =0->track director cosines, !=0->pc.eta
@@ -77,6 +69,14 @@ protected:
  private:
   GeneratorSpectators(const GeneratorSpectators &gen);
   GeneratorSpectators & operator=(const GeneratorSpectators &gen);
+
+  // Fermi smearing, beam divergence and crossing angle
+  void FermiTwoGaussian(Float_t A);
+  void ExtractFermi(Int_t id, Double_t *ddp);
+  void BeamDivergence(Double_t *pLab);
+  void BeamCrossing(Double_t *pLab);
+  void AddAngle(Double_t theta1, Double_t phi1, Double_t theta2, Double_t phi2,
+                Double_t *angle);
 
   ClassDef(GeneratorSpectators, 2) // Generator for spectators
 };

--- a/GeneratorSpectators/GeneratorSpectators.h
+++ b/GeneratorSpectators/GeneratorSpectators.h
@@ -11,8 +11,6 @@
 // or submit itself to any jurisdiction.
 //
 // Class to generate spectators for ZDC simulations
-//
-//
 
 #include <TGenerator.h>
 
@@ -20,8 +18,10 @@ class GeneratorSpectators : public TGenerator {
 
 public:
   GeneratorSpectators();
-  GeneratorSpectators(Int_t npart);
-  virtual ~GeneratorSpectators() {}
+  GeneratorSpectators(Int_t npart); // FIXME: not used at the moment
+
+  virtual ~GeneratorSpectators() {};
+
   virtual void Init();
   virtual void GenerateEvent();
   virtual int ImportParticles(TClonesArray *particles, Option_t *option);
@@ -31,24 +31,31 @@ public:
   void ExtractFermi(Int_t id, Double_t *ddp);
   void BeamDivergence(Double_t *pLab);
   void BeamCrossing(Double_t *pLab);
-  void AddAngle(Double_t theta1, Double_t phi1, Double_t theta2,
-  	            Double_t phi2, Double_t *angle);
+  void AddAngle(Double_t theta1, Double_t phi1, Double_t theta2, Double_t phi2,
+                Double_t *angle);
 
   // Parameters that could be set for generation
   void SetDebug() { fDebug = kTRUE; }
-  void SetParticle(Int_t pdgcode = 2112) { fPDGcode = pdgcode; };
-  void SetMomentum(Float_t ptot = 2510.) { fPmax = ptot;};
-  void SetDirection(Float_t eta = 0, Float_t cosx = 0, Float_t cosy = 0, Float_t cosz = 1)
-                   { fPseudoRapidity = eta; fCosx = cosx; fCosy = cosy; fCosz = cosz; };
-  void SetFermi(Int_t Fflag = 1) { fFermiflag = Fflag; };
-  void SetDivergence(Float_t bmdiv = 0.000032) { fBeamDiv = bmdiv; };
-  void SetCrossing(Float_t xingangle = 0.0001, Int_t xingplane = 2)
-             { fBeamCrossAngle = xingangle; fBeamCrossPlane = xingplane; };
+  void SetParticle(Int_t pdgcode = 2112) { fPDGcode = pdgcode; }
+  void SetMomentum(Float_t ptot = 2510.) { fPmax = ptot; }
+  void SetDirection(Float_t eta = 0, Float_t cosx = 0, Float_t cosy = 0,
+                    Float_t cosz = 1) {
+    fPseudoRapidity = eta;
+    fCosx = cosx;
+    fCosy = cosy;
+    fCosz = cosz;
+  }
+  void SetFermi(Int_t Fflag = 1) { fFermiflag = Fflag; }
+  void SetDivergence(Float_t bmdiv = 0.000032) { fBeamDiv = bmdiv; }
+  void SetCrossing(Float_t xingangle = 0.0001, Int_t xingplane = 2) {
+    fBeamCrossAngle = xingangle;
+    fBeamCrossPlane = xingplane;
+  }
 
   // Getters
   Double_t GetFermi2p(Int_t key) const { return fProbintp[key]; }
   Double_t GetFermi2n(Int_t key) const { return fProbintn[key]; }
-  Float_t GetZDirection() const {return fCosz; }
+  Float_t GetZDirection() const { return fCosz; }
 
 protected:
   Int_t    fDebug;              // debugging Fflag
@@ -71,7 +78,7 @@ protected:
   GeneratorSpectators(const GeneratorSpectators &gen);
   GeneratorSpectators & operator=(const GeneratorSpectators &gen);
 
-   ClassDef(GeneratorSpectators,1)  	// Generator for spectators
+  ClassDef(GeneratorSpectators, 2) // Generator for spectators
 };
 
 #endif

--- a/GeneratorSpectators/GeneratorSpectators.h
+++ b/GeneratorSpectators/GeneratorSpectators.h
@@ -32,7 +32,7 @@ public:
   void SetNpartFluctuation(Bool_t flag = kTRUE) { fNpartFluctuation = flag; }
   void SetNpart(Int_t npart = -1) { fNpart = npart; }
   void SetParticle(Int_t pdgcode = 2112) { fPDGcode = pdgcode; }
-  void SetMomentum(Float_t ptot = 2510.) { fPtot = ptot; }
+  void SetMomentum(Float_t ptot = 2680.) { fPtot = ptot; }
   void SetDirection(Float_t eta = 0, Float_t cosx = 0, Float_t cosy = 0,
                     Float_t cosz = 1) {
     fPseudoRapidity = eta;
@@ -41,8 +41,8 @@ public:
     fCosz = cosz;
   }
   void SetFermi(Bool_t flag = kTRUE) { fFermiflag = flag; }
-  void SetDivergence(Float_t bmdiv = 0.000032) { fBeamDiv = bmdiv; }
-  void SetCrossing(Float_t xingangle = 0.0001, Int_t xingplane = 2) {
+  void SetDivergence(Float_t bmdiv = 0.) { fBeamDiv = bmdiv; }
+  void SetCrossing(Float_t xingangle = 0., Int_t xingplane = 2) {
     fBeamCrossAngle = xingangle;
     fBeamCrossPlane = xingplane;
   }

--- a/GeneratorSpectators/GeneratorSpectators.h
+++ b/GeneratorSpectators/GeneratorSpectators.h
@@ -18,7 +18,6 @@ class GeneratorSpectators : public TGenerator {
 
 public:
   GeneratorSpectators();
-  GeneratorSpectators(Int_t npart); // FIXME: not used at the moment
 
   virtual ~GeneratorSpectators() {};
 
@@ -28,8 +27,10 @@ public:
 
   // Parameters that could be set for generation
   void SetDebug() { fDebug = kTRUE; }
+  void SetNpart(Int_t npart = 1) { fNpart = npart; }
   void SetParticle(Int_t pdgcode = 2112) { fPDGcode = pdgcode; }
   void SetMomentum(Float_t ptot = 2510.) { fPmax = ptot; }
+  void SetSampleMomentum(Int_t sample = 0) { fSamplePmax = sample; }
   void SetDirection(Float_t eta = 0, Float_t cosx = 0, Float_t cosy = 0,
                     Float_t cosz = 1) {
     fPseudoRapidity = eta;
@@ -50,9 +51,15 @@ public:
   Float_t GetZDirection() const { return fCosz; }
 
 protected:
-  Int_t    fDebug;              // Debugging flag
+  Int_t fDebug;                 // Debugging flag
+  Int_t fNpart;                 // Number of particles to be generated
+                                // if =-1 sample from realistic distribution
   Int_t    fPDGcode;            // Particle to be generated - can be n (2112) or p (2212)
   Float_t  fPmax;               // Maximum slow nucleon momentum
+  Int_t fSamplePmax;            // Sample momentum from realistic distribution
+                                // if =2 sample from uniform distribution
+                                // if =1 sample from realistic distribution
+                                // if =0 use fPmax as a fixed value
   Float_t  fPseudoRapidity;     // Pseudorapidity: =0->track director cosines, !=0->pc.eta
   Float_t  fCosx;               // Director cos of the track - x direction
   Float_t  fCosy;               // Director cos of the track - y direction
@@ -69,6 +76,10 @@ protected:
  private:
   GeneratorSpectators(const GeneratorSpectators &gen);
   GeneratorSpectators & operator=(const GeneratorSpectators &gen);
+
+  // Sampling of number of particles and momentum
+  Int_t SampleNpart();
+  Double_t SampleMomentum();
 
   // Fermi smearing, beam divergence and crossing angle
   void FermiTwoGaussian(Float_t A);


### PR DESCRIPTION
This PR includes the following changes for the GeneratorSpectators generator:

- format and cleanup the code
- add the possibility to generate multiple neutrons or protons per event
- add sampling of impact parameter and number of neutrons per event with parameterizations obtained from Pb-Pb at 5.02 TeV data
- add macro defining a wrapper generator compatible with O2Sim

@coppedis 